### PR TITLE
feat: add plugin architecture skeleton

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ import tasksRoutes from '@/routes/tasks';
 import tenantsRoutes from '@/routes/tenants';
 import usersRoutes from '@/routes/users';
 import workPermitsRoutes from '@/routes/work-permits';
+import { loadPlugins } from '@/plugins';
 
 // Import middleware
 import { authMiddleware } from '@/middleware/auth';
@@ -94,6 +95,9 @@ class MallOSApplication {
 
       // Setup routes
       this.setupRoutes();
+
+      // Load external plugins
+      await loadPlugins(this.app, this.io);
 
       // Setup Socket.IO
       this.setupSocketIO();

--- a/src/plugins/examplePlugin.ts
+++ b/src/plugins/examplePlugin.ts
@@ -1,0 +1,20 @@
+import express from 'express';
+import { Server } from 'socket.io';
+import { MallOSPlugin } from './index';
+import { logger } from '@/utils/logger';
+
+const examplePlugin: MallOSPlugin = {
+  register(app: express.Application, io: Server): void {
+    app.get('/plugin-example', (_req, res) => {
+      res.json({ success: true, message: 'Example plugin active' });
+    });
+
+    io.on('connection', (socket) => {
+      socket.emit('plugin-example', 'Plugin example connected');
+    });
+
+    logger.info('🚀 Example plugin registered');
+  }
+};
+
+export default examplePlugin;

--- a/src/plugins/index.ts
+++ b/src/plugins/index.ts
@@ -1,0 +1,33 @@
+import express from 'express';
+import { Server } from 'socket.io';
+import fs from 'fs';
+import path from 'path';
+import { logger } from '@/utils/logger';
+
+export interface MallOSPlugin {
+  register(app: express.Application, io: Server): void | Promise<void>;
+}
+
+export const loadPlugins = async (app: express.Application, io: Server): Promise<void> => {
+  const pluginsDir = __dirname;
+  const files = fs
+    .readdirSync(pluginsDir)
+    .filter((file) => file !== 'index.ts' && (file.endsWith('.ts') || file.endsWith('.js')));
+
+  for (const file of files) {
+    try {
+      const pluginPath = path.join(pluginsDir, file);
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const pluginModule = require(pluginPath);
+      const plugin: MallOSPlugin = pluginModule.default || pluginModule;
+      if (plugin && typeof plugin.register === 'function') {
+        await plugin.register(app, io);
+        logger.info(`✅ Plugin loaded: ${file}`);
+      }
+    } catch (error) {
+      logger.error(`❌ Failed to load plugin ${file}:`, error);
+    }
+  }
+};
+
+export default loadPlugins;


### PR DESCRIPTION
## Summary
- add plugin loader and example plugin for extensible architecture
- initialize plugins during app startup

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install --no-save jest ts-jest @types/jest --legacy-peer-deps` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68960f636718832e9594e6bbb44c7705