### PR TITLE
feat: add correlation ID middleware for structured request logging

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -43,6 +43,7 @@ import { loadPlugins } from '@/plugins';
 // Import middleware
 import { authMiddleware } from '@/middleware/auth';
 import { rateLimiter } from '@/middleware/rateLimiter';
+import { correlationIdMiddleware } from '@/middleware/correlationId';
 
 class MallOSApplication {
   private app: express.Application;
@@ -143,6 +144,9 @@ class MallOSApplication {
 
     // Compression
     this.app.use(compression());
+
+    // Correlation IDs for request tracing
+    this.app.use(correlationIdMiddleware);
 
     // Logging
     this.app.use(morgan('combined', {

--- a/src/middleware/correlationId.ts
+++ b/src/middleware/correlationId.ts
@@ -1,0 +1,17 @@
+import { AsyncLocalStorage } from 'async_hooks';
+import { v4 as uuidv4 } from 'uuid';
+import { Request, Response, NextFunction } from 'express';
+
+/**
+ * Middleware to attach a correlation ID to each request.
+ * The ID is stored in AsyncLocalStorage so log entries can include it.
+ */
+export const asyncLocalStorage = new AsyncLocalStorage<{ correlationId: string }>();
+
+export const correlationIdMiddleware = (req: Request, res: Response, next: NextFunction): void => {
+  const correlationId = (req.headers['x-correlation-id'] as string) || uuidv4();
+  res.setHeader('X-Correlation-ID', correlationId);
+  asyncLocalStorage.run({ correlationId }, () => next());
+};
+
+export default correlationIdMiddleware;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -5,6 +5,7 @@
 
 import winston from 'winston';
 import { config } from '@/config/config';
+import { asyncLocalStorage } from '@/middleware/correlationId';
 
 // Custom log format
 const logFormat = winston.format.combine(
@@ -14,7 +15,9 @@ const logFormat = winston.format.combine(
   winston.format.errors({ stack: true }),
   winston.format.json(),
   winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
-    let log = `${timestamp} [${level.toUpperCase()}]: ${message}`;
+    const store = asyncLocalStorage.getStore();
+    const correlationId = store?.correlationId;
+    let log = `${timestamp} [${level.toUpperCase()}]${correlationId ? ` [${correlationId}]` : ''}: ${message}`;
     
     if (stack) {
       log += `\n${stack}`;
@@ -35,7 +38,9 @@ const consoleFormat = winston.format.combine(
     format: 'YYYY-MM-DD HH:mm:ss'
   }),
   winston.format.printf(({ timestamp, level, message, stack, ...meta }) => {
-    let log = `${timestamp} [${level}]: ${message}`;
+    const store = asyncLocalStorage.getStore();
+    const correlationId = store?.correlationId;
+    let log = `${timestamp} [${level}]${correlationId ? ` [${correlationId}]` : ''}: ${message}`;
     
     if (stack) {
       log += `\n${stack}`;


### PR DESCRIPTION
## Summary
- add middleware to attach correlation IDs to incoming requests
- include correlation IDs in logger output
- register middleware in application setup

## Testing
- `npm test` *(fails: sh: 1: jest: not found)*
- `npm install` *(fails: unable to resolve dependency tree)*
- `npm install --legacy-peer-deps` *(fails: 403 Forbidden fetching @types/bcryptjs)*
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*

------
https://chatgpt.com/codex/tasks/task_e_689619305cec832e84a94b3a35284ff5