### PR TITLE
Add placeholder operational scripts

### DIFF
--- a/backup-test.sh
+++ b/backup-test.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MallOS Enterprise - Backup Verification Script
+# =============================================================================
+set -e
+
+mode="$1"
+
+echo "💾 Running backup test..."
+
+if [[ "$mode" == "--verify-restore" ]]; then
+    echo "🔄 Verifying backup restore capability..."
+    # Placeholder for actual restore verification logic
+    echo "ℹ️ No backup system configured; this is a placeholder verification."
+else
+    echo "ℹ️ To verify restore, run: $0 --verify-restore"
+fi
+
+echo "✅ Backup test completed."

--- a/monitoring-health-check.sh
+++ b/monitoring-health-check.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MallOS Enterprise - Monitoring Health Check Script
+# =============================================================================
+set -e
+
+echo "📊 Running monitoring health checks..."
+
+# Validate Prometheus configuration if the reloader is available
+if command -v prometheus-config-reloader >/dev/null 2>&1; then
+    echo "🔍 Validating Prometheus configuration..."
+    prometheus-config-reloader --validate
+else
+    echo "⚠️ prometheus-config-reloader is not installed; skipping Prometheus config validation."
+fi
+
+echo "✅ Monitoring health check completed."

--- a/ops-security-audit.sh
+++ b/ops-security-audit.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# =============================================================================
+# MallOS Enterprise - Security Audit Script
+# =============================================================================
+set -e
+
+echo "🔐 Running security audit checks..."
+
+# Check for kubectl and gather pod security contexts if available
+if command -v kubectl >/dev/null 2>&1; then
+    echo "📋 Collecting Kubernetes pod security contexts..."
+    kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}\t{.spec.securityContext}{"\n"}{end}'
+else
+    echo "⚠️ kubectl is not installed; skipping Kubernetes security context check."
+fi
+
+echo "✅ Security audit script completed."


### PR DESCRIPTION
## Summary
- add security audit script that checks for kubectl
- add monitoring health check script with Prometheus config validation
- add backup verification script with restore check option

## Testing
- `./ops-security-audit.sh`
- `kubectl get pods --all-namespaces -o jsonpath='{range .items[*]}{.metadata.name}{"\t"}{.spec.securityContext}{"\n"}{end}'` *(fails: command not found)*
- `./monitoring-health-check.sh`
- `prometheus-config-reloader --validate` *(fails: command not found)*
- `./backup-test.sh --verify-restore`
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689619795288832e8ae4c630b5323520