### PR TITLE
Add network configuration for load balancing and service mesh

### DIFF
--- a/NETWORK_GUIDE.md
+++ b/NETWORK_GUIDE.md
@@ -1,0 +1,19 @@
+# Network Improvements
+
+This repository now includes basic configurations to address common networking gaps.
+
+## Load Balancing
+- **Health Checks**: `docker-compose.yml` defines a healthcheck for the `nginx` service hitting `/healthz` on the upstream.
+- **Session Persistence**: `deploy/nginx.conf` uses `ip_hash` to keep clients on the same backend.
+- **Timeouts**: `proxy_connect_timeout`, `proxy_send_timeout`, and `proxy_read_timeout` protect against hanging connections.
+- **Circuit Breaker**: `proxy_next_upstream` with limited retries and `max_fails` in the upstream reduce pressure on unhealthy instances.
+
+The full configuration lives in [`deploy/nginx.conf`](deploy/nginx.conf).
+
+## Service Mesh
+- **Traffic Management**: [`deploy/service-mesh.yaml`](deploy/service-mesh.yaml) includes an Istio `DestinationRule` with `LEAST_CONN` balancing.
+- **Retry Policies**: The `VirtualService` section sets three retries with a two second per-try timeout.
+- **Rate Limiting**: An `EnvoyFilter` applies local rate limiting at 100 requests per second.
+- **Observability**: A `Telemetry` resource enables request metrics and Zipkin tracing for the service.
+
+Use these manifests as a starting point when deploying to a service mesh environment.

--- a/deploy/nginx.conf
+++ b/deploy/nginx.conf
@@ -1,0 +1,57 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log warn;
+pid        /var/run/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    keepalive_timeout  65;
+
+    upstream mallos_api {
+        ip_hash;  # session persistence based on client IP
+        server api:3001 max_fails=3 fail_timeout=30s;
+    }
+
+    server {
+        listen 80;
+
+        # Passive health check endpoint
+        location = /healthz {
+            proxy_pass http://mallos_api/health;
+            proxy_connect_timeout 5s;
+            proxy_read_timeout 5s;
+        }
+
+        location / {
+            proxy_pass http://mallos_api;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection 'upgrade';
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+
+            # Timeout settings
+            proxy_connect_timeout 5s;
+            proxy_send_timeout 30s;
+            proxy_read_timeout 30s;
+
+            # Circuit breaker-like settings
+            proxy_next_upstream error timeout http_500 http_502 http_503 http_504;
+            proxy_next_upstream_tries 3;
+        }
+    }
+}

--- a/deploy/service-mesh.yaml
+++ b/deploy/service-mesh.yaml
@@ -1,0 +1,95 @@
+apiVersion: networking.istio.io/v1beta1
+kind: DestinationRule
+metadata:
+  name: mallos-api
+spec:
+  host: mallos-api
+  trafficPolicy:
+    loadBalancer:
+      simple: LEAST_CONN
+    connectionPool:
+      tcp:
+        maxConnections: 100
+      http:
+        http1MaxPendingRequests: 100
+        maxRequestsPerConnection: 10
+        idleTimeout: 30s
+    outlierDetection:
+      consecutive5xxErrors: 3
+      interval: 5s
+      baseEjectionTime: 30s
+      maxEjectionPercent: 100
+---
+apiVersion: networking.istio.io/v1beta1
+kind: VirtualService
+metadata:
+  name: mallos-api
+spec:
+  hosts:
+    - mallos-api
+  http:
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: mallos-api
+            port:
+              number: 3001
+      retries:
+        attempts: 3
+        perTryTimeout: 2s
+        retryOn: gateway-error,connect-failure,refused-stream
+      timeout: 5s
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: mallos-api-rate-limit
+spec:
+  workloadSelector:
+    labels:
+      app: mallos-api
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: SIDECAR_INBOUND
+        listener:
+          filterChain:
+            filter:
+              name: envoy.filters.network.http_connection_manager
+              subFilter:
+                name: envoy.filters.http.router
+      patch:
+        operation: INSERT_BEFORE
+        value:
+          name: envoy.filters.http.local_ratelimit
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+            stat_prefix: http_local_rate_limiter
+            token_bucket:
+              max_tokens: 100
+              tokens_per_fill: 100
+              fill_interval: 1s
+            filter_enabled:
+              runtime_key: local_rate_limit_enabled
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+---
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: mallos-api-telemetry
+spec:
+  selector:
+    matchLabels:
+      app: mallos-api
+  metrics:
+    overrides:
+      - match:
+          metric: REQUEST_COUNT
+        enabled: true
+  tracing:
+    providers:
+      - name: "zipkin"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,26 @@ services:
   # =============================================================================
   # MAIN APPLICATION SERVICES
   # =============================================================================
-  
+
+  # Nginx reverse proxy and load balancer
+  nginx:
+    image: nginx:alpine
+    container_name: mallos-nginx
+    ports:
+      - "80:80"
+    volumes:
+      - ./deploy/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api
+    networks:
+      - mallos-network
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost/healthz || exit 1"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+
   # API Gateway & Main Application
   api:
     build:


### PR DESCRIPTION
## Summary
- add Nginx reverse proxy with health checks, sticky sessions, and circuit breaking
- provide Istio service mesh example for retries, rate limiting, and telemetry
- document networking improvements and new configuration files

## Testing
- `npm test` *(fails: jest: not found)*
- `npm install` *(fails: dependency conflict and 403 for @types/bcryptjs)*


------
https://chatgpt.com/codex/tasks/task_e_68961961280c832eb51d04a54ae69c06