### PR TITLE
Add Render deployment configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,4 +311,14 @@ CORS_ORIGIN=https://your-domain.com
 
 ---
 
-**MallOS Enterprise** - نظام إدارة المراكز التجارية المتقدم 🏢✨ 
+## Render Deployment
+
+A sample Render configuration is available in `render.yaml` to help deploy the platform:
+
+- **mallos-backend**: Node service that builds and runs the API (`npm install && npm run build` then `npm start`).
+- **mallos-frontend**: Static site built from the `frontend` directory.
+- **mallos-db**: Managed PostgreSQL database.
+
+Connect your repository in Render and it will detect this file to provision the services. Configure secrets like `JWT_SECRET` and `REDIS_URL` in the Render dashboard.
+
+**MallOS Enterprise** - نظام إدارة المراكز التجارية المتقدم 🏢✨

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,37 @@
+# Render deployment configuration for MallOS Enterprise
+# Defines backend Node service, frontend static site, and Postgres database
+
+databases:
+  - name: mallos-db
+    plan: free
+    region: oregon
+
+services:
+  - type: web
+    name: mallos-backend
+    env: node
+    region: oregon
+    plan: free
+    buildCommand: npm install && npm run build
+    startCommand: npm start
+    envVars:
+      - key: NODE_ENV
+        value: production
+      - key: PORT
+        value: 3001
+      - fromDatabase:
+          name: mallos-db
+          property: connectionString
+        key: DATABASE_URL
+      # Uncomment and set values for additional services
+      - key: REDIS_URL
+        sync: false
+      - key: JWT_SECRET
+        sync: false
+
+  - type: web
+    name: mallos-frontend
+    env: static
+    plan: free
+    buildCommand: cd frontend && npm install && npm run build
+    staticPublishPath: frontend/dist


### PR DESCRIPTION
## Summary
- add `render.yaml` with backend, frontend, and postgres services for Render deployment
- document Render deployment steps in README
- remove region from frontend static service, as static sites cannot specify a region

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963651fbb8832ea5a265ed1d673864