### PR TITLE
chore: use legacy peer deps in Dockerfiles

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,8 @@ COPY package*.json ./
 COPY tsconfig.json ./
 
 # Install all dependencies (including dev dependencies)
-RUN npm install
+# Bypass peer dependency conflicts
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -6,9 +6,9 @@
 FROM node:18-alpine AS builder
 WORKDIR /app
 
-# Install dependencies
+# Install dependencies (legacy peer deps to avoid conflicts)
 COPY package*.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 
 # Copy source code
 COPY . .
@@ -38,8 +38,9 @@ CMD ["nginx", "-g", "daemon off;"]
 FROM node:18-alpine AS development
 WORKDIR /app
 
+# Install dependencies for development (legacy peer deps)
 COPY package*.json ./
-RUN npm install
+RUN npm install --legacy-peer-deps
 COPY . .
 EXPOSE 3000
 CMD ["npm", "run", "dev"] 


### PR DESCRIPTION
## Summary
- bypass npm peer dependency resolution by using `--legacy-peer-deps`

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.* file)*
- `cd frontend && npm run lint` *(fails: ESLint couldn't find the config "@typescript-eslint/recommended" to extend from)*

------
https://chatgpt.com/codex/tasks/task_e_68963d04f0d0832e9e4d50ab17cc9e1d