### PR TITLE
fix: replace deprecated sentry dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "bull": "^4.11.3",
     "express-prometheus-middleware": "^1.2.0",
     "prom-client": "^14.2.0",
-    "sentry-node": "^7.64.0",
+    "@sentry/node": "^7.64.0",
     "newrelic": "^11.0.0",
     "mqtt": "^5.0.3",
     "aedes": "^0.48.1",


### PR DESCRIPTION
## Summary
- replace nonexistent `sentry-node` package with official `@sentry/node`

## Testing
- `npm install --package-lock-only --legacy-peer-deps --no-audit --no-fund` *(fails: 403 Forbidden for @sentry/node)*
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68963fb4928c832ea63ed92a2ac36efe