### PR TITLE
Secure password reset token delivery

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -5,6 +5,7 @@
 
 import express from 'express';
 import { AuthService } from '@/services/AuthService';
+import { EmailService } from '@/services/EmailService';
 import { User, UserStatus, UserRole } from '@/models/User';
 import { database } from '@/config/database';
 import { logger } from '@/utils/logger';
@@ -77,9 +78,13 @@ router.post('/password-reset/request', async (req, res) => {
       return res.status(404).json({ message: 'User not found' });
     }
     const token = await AuthService.initiatePasswordReset(user.id);
-    // TODO: Send token via email
+    await EmailService.sendMail({
+      to: user.email,
+      subject: 'Password Reset Request',
+      text: `Use this token to reset your password: ${token}`,
+    });
     logger.info(`Password reset requested for ${email}`);
-    return res.json({ message: 'Password reset email sent', token });
+    return res.json({ message: 'Password reset email sent' });
   } catch (err) {
     logger.error('Password reset request error', err);
     return res.status(500).json({ message: 'Password reset request failed' });

--- a/src/services/EmailService.ts
+++ b/src/services/EmailService.ts
@@ -1,0 +1,28 @@
+import nodemailer from 'nodemailer';
+import { config } from '@/config/config';
+import { logger } from '@/utils/logger';
+
+export class EmailService {
+  private static transporter = nodemailer.createTransport({
+    service: 'SendGrid',
+    auth: {
+      user: 'apikey',
+      pass: config.services.sendgrid.apiKey,
+    },
+  });
+
+  static async sendMail(options: { to: string; subject: string; text: string; html?: string }): Promise<void> {
+    try {
+      await EmailService.transporter.sendMail({
+        from: `${config.services.sendgrid.fromName} <${config.services.sendgrid.fromEmail}>`,
+        ...options,
+      });
+      logger.info(`Email sent to ${options.to}`);
+    } catch (err) {
+      logger.error('Email send failed', err);
+      throw err;
+    }
+  }
+}
+
+export default EmailService;


### PR DESCRIPTION
## Summary
- Omit password reset token from API response and send it via email
- Add nodemailer-based email service for password reset notifications

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689642d9cf00832ebf92babe253d9078