### PR TITLE
feat(auth): set SameSite=Lax for session cookie

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ POST /api/auth/logout
 POST /api/auth/refresh
 ```
 
+**Cookie Policy:** The `sessionId` cookie is issued with `SameSite=Lax` to mitigate CSRF while ensuring standard navigation continues to send credentials.
+
 #### المستأجرين
 ```http
 GET /api/tenants

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -59,7 +59,11 @@ router.post('/login', async (req, res) => {
     const accessToken = AuthService.generateAccessToken(user);
     const refreshToken = AuthService.generateRefreshToken(user);
     const sessionId = await AuthService.createSession(user.id, { role: user.role, tenantId: user.tenantId });
-    res.cookie('sessionId', sessionId, { httpOnly: true, secure: true });
+    res.cookie('sessionId', sessionId, {
+      httpOnly: true,
+      secure: true,
+      sameSite: 'lax'
+    });
     return res.json({ accessToken, refreshToken, sessionId });
   } catch (err) {
     logger.error('Login error', err);


### PR DESCRIPTION
## Summary
- add SameSite=Lax to session cookie
- document session cookie policy in auth docs

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_689642db2a10832ebdebd3b6392b20f4