### PR TITLE
feat: add cookie parser middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "helmet": "^7.0.0",
     "cors": "^2.8.5",
     "compression": "^1.7.4",
+    "cookie-parser": "^1.4.6",
     "morgan": "^1.10.0",
     "winston": "^3.10.0",
     "dotenv": "^16.3.1",

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { logger } from '@/utils/logger';
 import compression from 'compression';
 import cors from 'cors';
 import express from 'express';
+import cookieParser from 'cookie-parser';
 import helmet from 'helmet';
 import { createServer } from 'http';
 import morgan from 'morgan';
@@ -158,6 +159,9 @@ class MallOSApplication {
     // Body parsing
     this.app.use(express.json({ limit: '10mb' }));
     this.app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+    // Cookie parsing
+    this.app.use(cookieParser());
 
     // Audit logging (global)
     this.app.use(auditLog);


### PR DESCRIPTION
## Summary
- add cookie-parser dependency
- enable cookie parsing middleware in app setup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689642d68fc4832e85c5c4bf2fe9c217