### PR TITLE
fix: add cmake and build deps for opencv4nodejs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,16 @@ RUN apk add --no-cache \
     python3 \
     make \
     g++ \
+    cmake \
     git \
     curl \
+    build-base \
+    pkgconfig \
+    libjpeg-turbo-dev \
+    zlib-dev \
+    libpng-dev \
+    libwebp-dev \
+    tiff-dev \
     && rm -rf /var/cache/apk/*
 
 # Copy package files
@@ -86,9 +94,17 @@ RUN apk add --no-cache \
     python3 \
     make \
     g++ \
+    cmake \
     git \
     curl \
     vim \
+    build-base \
+    pkgconfig \
+    libjpeg-turbo-dev \
+    zlib-dev \
+    libpng-dev \
+    libwebp-dev \
+    tiff-dev \
     && rm -rf /var/cache/apk/*
 
 # Copy package files


### PR DESCRIPTION
## Summary
- install cmake and native libraries required to build opencv4nodejs

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.js file)*

------
https://chatgpt.com/codex/tasks/task_e_689645ca932c832eb5eeff0560e28efc