### PR TITLE
fix: use env example and drop uploads copy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,7 @@ RUN apk add --no-cache \
 
 COPY package*.json ./
 COPY tsconfig.json ./
-COPY .env.example ./
+COPY env.example ./
 
 RUN npm install --legacy-peer-deps
 
@@ -47,8 +47,7 @@ COPY package*.json ./
 RUN npm install --legacy-peer-deps && npm cache clean --force
 
 COPY --from=builder --chown=nodejs:nodejs /app/dist ./dist
-COPY --chown=nodejs:nodejs .env.example ./
-COPY --chown=nodejs:nodejs ./uploads ./uploads
+COPY --chown=nodejs:nodejs env.example ./
 
 RUN mkdir -p /app/logs /app/temp /app/uploads && \
     chown -R nodejs:nodejs /app


### PR DESCRIPTION
## Summary
- copy `env.example` in both build and production stages
- drop unused `uploads` copy step

## Testing
- `npm test`
- `docker build -t mallos-test .` *(fails: command not found: docker)*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*
- `apt-get install -y docker.io` *(fails: Unable to locate package docker.io)*

------
https://chatgpt.com/codex/tasks/task_e_68964b2bccd8832eb16371f27708201d