### PR TITLE
Invalidate MFA code after verification

### DIFF
--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -90,8 +90,13 @@ export class AuthService {
    * Verify MFA code
    */
   static async verifyMfaCode(userId: string, code: string): Promise<boolean> {
-    const stored = await redis.get(`mfa:${userId}`);
-    return stored === code;
+    const key = `mfa:${userId}`;
+    const stored = await redis.get(key);
+    if (stored === code) {
+      await redis.del(key);
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/tests/verifyMfaCode.test.js
+++ b/tests/verifyMfaCode.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+// Read AuthService source
+const authServicePath = path.resolve(__dirname, '../src/services/AuthService.ts');
+const source = fs.readFileSync(authServicePath, 'utf8');
+
+function extractMethod(name) {
+  const start = source.indexOf(`static async ${name}`);
+  if (start === -1) throw new Error(`Method ${name} not found`);
+  const braceStart = source.indexOf('{', start);
+  let index = braceStart + 1;
+  let depth = 1;
+  while (depth > 0 && index < source.length) {
+    const char = source[index++];
+    if (char === '{') depth++;
+    else if (char === '}') depth--;
+  }
+  const method = source.slice(start, index);
+  return method
+    .replace(/userId: string/g, 'userId')
+    .replace(/code: string/g, 'code')
+    .replace(/: Promise<[^>]+>/g, '')
+    .replace(/: string/g, '');
+}
+
+const classBody = `
+const crypto = require('node:crypto');
+const redis = mockRedis;
+class AuthService {
+${extractMethod('generateMfaCode')}
+${extractMethod('verifyMfaCode')}
+}
+module.exports = { AuthService };
+`;
+
+// Mock Redis implementation
+const store = new Map();
+const mockRedis = {
+  async get(key) {
+    return store.has(key) ? store.get(key) : null;
+  },
+  async set(key, value, ..._args) {
+    store.set(key, value);
+  },
+  async del(key) {
+    store.delete(key);
+  },
+};
+
+const context = { require, module: { exports: {} }, mockRedis };
+vm.runInNewContext(classBody, context);
+const { AuthService } = context.module.exports;
+
+const redis = mockRedis;
+
+test('verifyMfaCode removes code after successful verification', async () => {
+  const userId = 'user1';
+  const code = await AuthService.generateMfaCode(userId);
+
+  const firstVerify = await AuthService.verifyMfaCode(userId, code);
+  assert.equal(firstVerify, true);
+  assert.equal(await redis.get(`mfa:${userId}`), null);
+
+  const secondVerify = await AuthService.verifyMfaCode(userId, code);
+  assert.equal(secondVerify, false);
+});


### PR DESCRIPTION
## Summary
- ensure AuthService.verifyMfaCode deletes MFA key when code matches
- test that a valid MFA code cannot be reused after successful verification

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964b2d6978832ea2fd8d3a863aa14d