### PR TITLE
chore: add curl to production image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ ENV OPENCV4NODEJS_DISABLE_AUTOBUILD=1
 
 WORKDIR /app
 
+RUN apk add --no-cache curl
 RUN addgroup -g 1001 -S nodejs && \
     adduser -S nodejs -u 1001
 


### PR DESCRIPTION
## Summary
- install curl in production Docker image

## Testing
- `npm test`
- `docker build -t mallos-enterprise-test .` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68964b2ce93c832e9866d255914a7a09