### PR TITLE
Use AuthService for MFA code tests

### DIFF
--- a/src/services/AuthService.js
+++ b/src/services/AuthService.js
@@ -1,0 +1,9 @@
+const crypto = require('node:crypto');
+
+class AuthService {
+  static generateMfaCode(randomFn = crypto.randomInt) {
+    return randomFn(100000, 1000000).toString();
+  }
+}
+
+module.exports = { AuthService };

--- a/tests/generateMfaCode.test.js
+++ b/tests/generateMfaCode.test.js
@@ -1,24 +1,21 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const crypto = require('node:crypto');
 
-function generateMfaCode(randomFn = crypto.randomInt) {
-  return randomFn(100000, 1000000).toString();
-}
+const { AuthService } = require('../src/services/AuthService');
 
-test('generateMfaCode returns 6-digit code within range', () => {
-  const code = generateMfaCode();
+test('AuthService.generateMfaCode returns 6-digit code within range', () => {
+  const code = AuthService.generateMfaCode(() => 123456);
   assert.equal(code.length, 6);
   const num = Number(code);
   assert.ok(num >= 100000 && num <= 999999);
 });
 
-test('generateMfaCode handles lower bound', () => {
-  const code = generateMfaCode(() => 100000);
+test('AuthService.generateMfaCode handles lower bound', () => {
+  const code = AuthService.generateMfaCode(() => 100000);
   assert.equal(code, '100000');
 });
 
-test('generateMfaCode handles upper bound', () => {
-  const code = generateMfaCode(() => 999999);
+test('AuthService.generateMfaCode handles upper bound', () => {
+  const code = AuthService.generateMfaCode(() => 999999);
   assert.equal(code, '999999');
 });


### PR DESCRIPTION
## Summary
- replace local MFA code generator in tests with AuthService
- add minimal AuthService helper exposing generateMfaCode
- verify code length, range, and bounds via deterministic stubs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68964b2df814832ea9b482b1b4dc3d3c