### PR TITLE
fix: remove build fallback

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "private": true,
   "engines": { "node": ">=18 <21" },
   "scripts": {
-    "build": "tsc -p tsconfig.json || echo 'no ts build'",
+    "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js || node dist/index.js",
     "dev": "ts-node src/server.ts || ts-node src/index.ts",
     "migrate:prod": "typeorm migration:run"
   },
- codex/fix-render-stability-and-security-issues
+
   "keywords": [
     "mall-management",
     "enterprise",
@@ -148,8 +148,4 @@
     "url": "https://github.com/Mosleh92/ops/issues"
   },
   "homepage": "https://mallos.com"
-=======
-  "dependencies": {},
-  "devDependencies": {}
- main
 }


### PR DESCRIPTION
## Summary
- drop shell fallback from build script to stop on TypeScript errors
- clean up stray markers in package.json

## Testing
- `npm run build` (fails: src/routes/auth.ts line errors)
- `npm run build` with intentional error (tsconfig pointed to bad test file)

------
https://chatgpt.com/codex/tasks/task_e_68998e1e8d50832ea76752817a6f8c92