### PR TITLE
Align container port configuration to 3001

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,6 @@ COPY --from=build /app/package*.json ./
 # Install only production dependencies; fallback when lockfile is absent
 RUN if [ -f package-lock.json ]; then npm ci --omit=dev; else npm install --omit=dev; fi
 COPY --from=build /app/dist ./dist
-EXPOSE 10000
-HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1:${PORT:-10000}/healthz || exit 1
+EXPOSE 3001
+HEALTHCHECK --interval=30s --timeout=3s CMD wget -qO- http://127.0.0.1:${PORT:-3001}/healthz || exit 1
 CMD ["node", "dist/server.js"]

--- a/env.example
+++ b/env.example
@@ -1,5 +1,5 @@
 NODE_ENV=production
-PORT=10000
+PORT=3001
 CORS_ORIGIN=https://your-frontend.onrender.com
 # DATABASE_URL از Render تزریق می‌شود
 # REDIS_URL از Render تزریق می‌شود


### PR DESCRIPTION
## Summary
- expose port 3001 in Dockerfile and health check
- set runtime PORT to 3001 in env.example

## Testing
- `npm test` *(fails: Invalid package.json)*
- `docker build -t ops-app .` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68998e1fd0f0832ea24845f10ce5d269