### PR TITLE
Refactor server initialization into modules with tests

### DIFF
--- a/src/configureWebSocket.ts
+++ b/src/configureWebSocket.ts
@@ -1,0 +1,79 @@
+import { Server } from 'socket.io';
+import { aiAnalyticsService } from '@/services/AIAnalyticsService';
+import { iotService } from '@/services/IoTService';
+import { logger } from '@/utils/logger';
+
+export function configureWebSocket(io: Server): void {
+  io.use((socket, next) => {
+    const token = (socket.handshake as any).auth.token;
+    if (!token) {
+      return next(new Error('Authentication error'));
+    }
+    socket.data.user = { id: 'user-id', mallId: 'mall-id' };
+    next();
+  });
+
+  io.on('connection', (socket) => {
+    logger.info(`🔌 Client connected: ${socket.id}`);
+    socket.join(`mall-${(socket.data as any).user.mallId}`);
+
+    socket.on('subscribe-iot-data', (data) => {
+      const { sensorType, deviceId } = data;
+      socket.join(`iot-${sensorType}-${deviceId}`);
+      logger.info(`📡 Client ${socket.id} subscribed to IoT data: ${sensorType}`);
+    });
+
+    socket.on('subscribe-ai-predictions', (data) => {
+      const { type } = data;
+      socket.join(`ai-${type}`);
+      logger.info(`🤖 Client ${socket.id} subscribed to AI predictions: ${type}`);
+    });
+
+    socket.on('subscribe-cv-alerts', (data) => {
+      const { cameraId } = data;
+      socket.join(`cv-${cameraId}`);
+      logger.info(`👁️ Client ${socket.id} subscribed to CV alerts: ${cameraId}`);
+    });
+
+    socket.on('disconnect', () => {
+      logger.info(`🔌 Client disconnected: ${socket.id}`);
+    });
+  });
+
+  iotService.on('sensorData', (data) => {
+    io.to(`iot-${data.sensorType}-${data.deviceId}`).emit('sensor-data', data);
+    io.to(`mall-${data.mallId}`).emit('iot-update', {
+      type: 'sensor-data',
+      data,
+    });
+  });
+
+  iotService.on('sensorAlert', (alert) => {
+    io.to(`mall-${alert.mallId}`).emit('iot-alert', {
+      type: 'sensor-alert',
+      data: alert,
+    });
+  });
+
+  iotService.on('deviceStatusUpdate', (update) => {
+    io.to(`mall-${update.mallId}`).emit('device-status', {
+      type: 'device-status',
+      data: update,
+    });
+  });
+
+  aiAnalyticsService.on('predictionCompleted', (prediction) => {
+    io.to(`ai-${prediction.type}`).emit('ai-prediction', {
+      type: 'prediction-completed',
+      data: prediction,
+    });
+  });
+
+  aiAnalyticsService.on('modelTrained', (model) => {
+    io.to(`mall-${model.mallId}`).emit('ai-model', {
+      type: 'model-trained',
+      data: model,
+    });
+  });
+}
+

--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -1,0 +1,34 @@
+import { Server as HTTPServer } from 'http';
+import { Server as IOServer } from 'socket.io';
+import { aiAnalyticsService } from '@/services/AIAnalyticsService';
+import { iotService } from '@/services/IoTService';
+import { databaseManager } from '@/config/database';
+import { redis } from '@/config/redis';
+import { logger } from '@/utils/logger';
+
+export function setupGracefulShutdown(server: HTTPServer, io: IOServer): void {
+  const gracefulShutdown = async (signal: string) => {
+    logger.info(`🛑 Received ${signal}. Starting graceful shutdown...`);
+    try {
+      io.close(() => {
+        logger.info('✅ Socket.IO server closed');
+      });
+      server.close(() => {
+        logger.info('✅ HTTP server closed');
+      });
+      await iotService.cleanup();
+      await aiAnalyticsService.cleanup();
+      await databaseManager.close();
+      await redis.disconnect();
+      logger.info('✅ Graceful shutdown completed');
+      process.exit(0);
+    } catch (error) {
+      logger.error('❌ Error during graceful shutdown:', error);
+      process.exit(1);
+    }
+  };
+
+  process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
+  process.on('SIGINT', () => gracefulShutdown('SIGINT'));
+}
+

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,500 +6,76 @@
 import { config } from '@/config/config';
 import { databaseManager } from '@/config/database';
 import { redis } from '@/config/redis';
-import { AuditLog } from '@/models/AuditLog';
-import { IntegrationConfig } from '@/models/IntegrationConfig';
 import { aiAnalyticsService } from '@/services/AIAnalyticsService';
 import { iotService } from '@/services/IoTService';
 import { logger } from '@/utils/logger';
-import compression from 'compression';
-import cors from 'cors';
 import express from 'express';
-import cookieParser from 'cookie-parser';
-import helmet from 'helmet';
 import { createServer } from 'http';
-import morgan from 'morgan';
-import os from 'os';
-import promClient from 'prom-client';
 import { Server } from 'socket.io';
-import { getRepository } from 'typeorm';
-
-// Import routes
-import { auditLog } from '@/middleware/audit';
-import aiRoutes from '@/routes/ai';
-import auditLogRouter from '@/routes/audit-logs';
-import authRoutes from '@/routes/auth';
-import cleaningRoutes from '@/routes/cleaning';
-import dashboardRoutes from '@/routes/dashboard';
-import integrationsRouter from '@/routes/integrations';
-import iotRoutes from '@/routes/iot';
-import mallsRoutes from '@/routes/malls';
-import tasksRoutes from '@/routes/tasks';
-import tenantsRoutes from '@/routes/tenants';
-import usersRoutes from '@/routes/users';
-import workPermitsRoutes from '@/routes/work-permits';
 import { loadPlugins } from '@/plugins';
+import { setupMiddleware } from './setupMiddleware';
+import { registerRoutes } from './registerRoutes';
+import { configureWebSocket } from './configureWebSocket';
+import { setupGracefulShutdown } from './gracefulShutdown';
 
-// Import middleware
-import { authMiddleware } from '@/middleware/auth';
-import { rateLimiter } from '@/middleware/rateLimiter';
-import { correlationIdMiddleware } from '@/middleware/correlationId';
+const app = express();
+const server = createServer(app);
+const io = new Server(server, {
+  cors: {
+    origin: config.app.corsOrigin,
+    methods: ['GET', 'POST'],
+  },
+});
 
-class MallOSApplication {
-  private app: express.Application;
-  private server: any;
-  private io: Server;
-  private isInitialized = false;
-
-  constructor() {
-    this.app = express();
-    this.server = createServer(this.app);
-    this.io = new Server(this.server, {
-      cors: {
-        origin: config.app.corsOrigin,
-        methods: ['GET', 'POST']
-      }
-    });
-  }
-
-  /**
-   * Initialize the application
-   */
-  async initialize(): Promise<void> {
-    try {
-      if (this.isInitialized) return;
-
-      logger.info('🚀 Initializing MallOS Enterprise Application...');
-
-      // Initialize database
-      await databaseManager.initialize();
-      logger.info('✅ Database initialized');
-
-      // Initialize Redis
-      await redis.connect();
-      logger.info('✅ Redis connected');
-
-      // Initialize IoT Service
-      await iotService.initialize();
-      logger.info('✅ IoT Service initialized');
-
-      // Initialize AI Analytics Service
-      await aiAnalyticsService.initialize();
-      logger.info('✅ AI Analytics Service initialized');
-
-      // Setup middleware
-      this.setupMiddleware();
-
-      // Setup routes
-      this.setupRoutes();
-
-      // Load external plugins
-      await loadPlugins(this.app, this.io);
-
-      // Setup Socket.IO
-      this.setupSocketIO();
-
-      // Setup error handling
-      this.setupErrorHandling();
-
-      // Setup graceful shutdown
-      this.setupGracefulShutdown();
-
-      this.isInitialized = true;
-      logger.info('✅ MallOS Enterprise Application initialized successfully');
-    } catch (error) {
-      logger.error('❌ Failed to initialize application:', error);
-      throw error;
+function setupErrorHandling(app: express.Application): void {
+  app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+    if (err.name === 'UnauthorizedError') {
+      return res.status(401).json({ success: false, error: 'Unauthorized' });
     }
-  }
-
-  /**
-   * Setup middleware
-   */
-  private setupMiddleware(): void {
-    // Security middleware
-    this.app.use(helmet({
-      contentSecurityPolicy: {
-        directives: {
-          defaultSrc: ["'self'"],
-          styleSrc: ["'self'", "'unsafe-inline'"],
-          scriptSrc: ["'self'"],
-          imgSrc: ["'self'", "data:", "https:"],
-        },
-      },
-    }));
-
-    // CORS
-    this.app.use(cors({
-      origin: config.app.corsOrigin,
-      credentials: true
-    }));
-
-    // Rate limiting (global, can be overridden per route)
-    this.app.use(rateLimiter);
-
-    // Compression
-    this.app.use(compression());
-
-    // Correlation IDs for request tracing
-    this.app.use(correlationIdMiddleware);
-
-    // Logging
-    this.app.use(morgan('combined', {
-      stream: {
-        write: (message: string) => logger.info(message.trim())
-      }
-    }));
-
-    // Body parsing
-    this.app.use(express.json({ limit: '10mb' }));
-    this.app.use(express.urlencoded({ extended: true, limit: '10mb' }));
-
-    // Cookie parsing
-    this.app.use(cookieParser());
-
-    // Audit logging (global)
-    this.app.use(auditLog);
-
-    // Health and metrics endpoints
-    this.app.get('/healthz', (_req, res) => {
-      res.status(200).json({ status: 'ok' });
-    });
-
-    this.app.get('/health', async (req, res) => {
-      res.json({
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-        version: config.app.version,
-        environment: config.app.environment,
-        nodeEnv: process.env.NODE_ENV,
-        uptime: process.uptime(),
-        memory: process.memoryUsage(),
-        memoryPercent: (process.memoryUsage().heapUsed / process.memoryUsage().heapTotal) * 100,
-        cpu: os.loadavg(),
-        dependencies: {
-          database: databaseManager.getStatus(),
-          redis: redis.status,
-          integrations: 'ok', // Placeholder, see /health/integrations
-          security: 'ok', // Placeholder, see /health/security
-        }
-      });
-    });
-
-    this.app.get('/health/database', async (req, res) => {
-      try {
-        const status = databaseManager.getStatus();
-        const pool = databaseManager.getPoolStatus ? databaseManager.getPoolStatus() : {};
-        const repo = getRepository(AuditLog);
-        const count = await repo.count();
-        res.json({
-          status,
-          pool,
-          auditLogCount: count,
-          migration: databaseManager.getMigrationStatus ? await databaseManager.getMigrationStatus() : 'unknown',
-        });
-      } catch (err) {
-        res.status(500).json({ status: 'error', error: err.message });
-      }
-    });
-
-    this.app.get('/health/integrations', async (req, res) => {
-      try {
-        const repo = getRepository(IntegrationConfig);
-        const integrations = await repo.find();
-        // Simulate connectivity checks and last sync/error status
-        const statuses = integrations.map(i => ({
-          id: i.id,
-          name: i.name,
-          type: i.type,
-          status: i.status,
-          lastSync: i['lastSync'] || null,
-          errorCount: i['errorCount'] || 0,
-        }));
-        res.json({ integrations: statuses });
-      } catch (err) {
-        res.status(500).json({ status: 'error', error: err.message });
-      }
-    });
-
-    this.app.get('/health/security', (req, res) => {
-      // Simulate security middleware status
-      res.json({
-        helmet: true,
-        cors: true,
-        rateLimiting: true,
-        recentSecurityEvents: [], // Could be populated from logs
-        authentication: true,
-        auditLogging: true,
-      });
-    });
-
-    this.app.get('/health/audit', async (req, res) => {
-      try {
-        const repo = getRepository(AuditLog);
-        const count = await repo.count();
-        const recent = await repo.find({ order: { timestamp: 'DESC' }, take: 10 });
-        res.json({
-          logVolume: count,
-          recentLogs: recent,
-          retentionPolicy: process.env.AUDIT_RETENTION_DAYS || 90,
-          cleanupStatus: 'ok', // Placeholder
-        });
-      } catch (err) {
-        res.status(500).json({ status: 'error', error: err.message });
-      }
-    });
-
-    // Prometheus metrics endpoint
-    const collectDefaultMetrics = promClient.collectDefaultMetrics;
-    collectDefaultMetrics();
-    this.app.get('/metrics', async (req, res) => {
-      res.set('Content-Type', promClient.register.contentType);
-      res.end(await promClient.register.metrics());
-    });
-  }
-
-  /**
-   * Setup routes
-   */
-  private setupRoutes(): void {
-    // API routes
-    this.app.use('/api/auth', authRoutes);
-    this.app.use('/api/dashboard', authMiddleware, dashboardRoutes);
-    this.app.use('/api/users', authMiddleware, usersRoutes);
-    this.app.use('/api/malls', authMiddleware, mallsRoutes);
-    this.app.use('/api/tenants', authMiddleware, tenantsRoutes);
-    this.app.use('/api/work-permits', authMiddleware, workPermitsRoutes);
-    this.app.use('/api/tasks', tasksRoutes);
-
-    // IoT & AI routes
-    this.app.use('/api/iot', iotRoutes);
-    this.app.use('/api/ai', aiRoutes);
-
-    // --- Register enhanced integration router with full security stack ---
-    this.app.use('/api/integrations', integrationsRouter);
-
-    // --- Register audit log router with full security stack ---
-    this.app.use('/api/audit-logs', auditLogRouter);
-
-    // --- Register cleaning management router ---
-    this.app.use('/api/cleaning', cleaningRoutes);
-
-    // API documentation
-    this.app.get('/api', (req, res) => {
-      res.json({
-        name: 'MallOS Enterprise API',
-        version: config.app.version,
-        description: 'IoT & AI Integration Hub for Mall Management',
-        endpoints: {
-          auth: '/api/auth',
-          dashboard: '/api/dashboard',
-          users: '/api/users',
-          malls: '/api/malls',
-          tenants: '/api/tenants',
-          workPermits: '/api/work-permits',
-          tasks: '/api/tasks',
-          iot: '/api/iot',
-          ai: '/api/ai',
-          integrations: '/api/integrations',
-          auditLogs: '/api/audit-logs',
-          cleaning: '/api/cleaning'
-        }
-      });
-    });
-
-    // 404 handler
-    this.app.use('*', (req, res) => {
-      res.status(404).json({
-        error: 'Endpoint not found',
-        path: req.originalUrl
-      });
-    });
-  }
-
-  /**
-   * Setup Socket.IO for real-time communication
-   */
-  private setupSocketIO(): void {
-    // Authentication middleware for Socket.IO
-    this.io.use((socket, next) => {
-      const token = socket.handshake.auth.token;
-      if (!token) {
-        return next(new Error('Authentication error'));
-      }
-      // Verify token and attach user data
-      // This is a simplified implementation
-      socket.data.user = { id: 'user-id', mallId: 'mall-id' };
-      next();
-    });
-
-    this.io.on('connection', (socket) => {
-      logger.info(`🔌 Client connected: ${socket.id}`);
-
-      // Join mall-specific room
-      socket.join(`mall-${socket.data.user.mallId}`);
-
-      // Handle IoT data subscriptions
-      socket.on('subscribe-iot-data', (data) => {
-        const { sensorType, deviceId } = data;
-        socket.join(`iot-${sensorType}-${deviceId}`);
-        logger.info(`📡 Client ${socket.id} subscribed to IoT data: ${sensorType}`);
-      });
-
-      // Handle AI predictions subscriptions
-      socket.on('subscribe-ai-predictions', (data) => {
-        const { type } = data;
-        socket.join(`ai-${type}`);
-        logger.info(`🤖 Client ${socket.id} subscribed to AI predictions: ${type}`);
-      });
-
-      // Handle computer vision alerts subscriptions
-      socket.on('subscribe-cv-alerts', (data) => {
-        const { cameraId } = data;
-        socket.join(`cv-${cameraId}`);
-        logger.info(`👁️ Client ${socket.id} subscribed to CV alerts: ${cameraId}`);
-      });
-
-      socket.on('disconnect', () => {
-        logger.info(`🔌 Client disconnected: ${socket.id}`);
-      });
-    });
-
-    // Forward IoT events to Socket.IO
-    iotService.on('sensorData', (data) => {
-      this.io.to(`iot-${data.sensorType}-${data.deviceId}`).emit('sensor-data', data);
-      this.io.to(`mall-${data.mallId}`).emit('iot-update', {
-        type: 'sensor-data',
-        data
-      });
-    });
-
-    iotService.on('sensorAlert', (alert) => {
-      this.io.to(`mall-${alert.mallId}`).emit('iot-alert', {
-        type: 'sensor-alert',
-        data: alert
-      });
-    });
-
-    iotService.on('deviceStatusUpdate', (update) => {
-      this.io.to(`mall-${update.mallId}`).emit('device-status', {
-        type: 'device-status',
-        data: update
-      });
-    });
-
-    // Forward AI events to Socket.IO
-    aiAnalyticsService.on('predictionCompleted', (prediction) => {
-      this.io.to(`ai-${prediction.type}`).emit('ai-prediction', {
-        type: 'prediction-completed',
-        data: prediction
-      });
-    });
-
-    aiAnalyticsService.on('modelTrained', (model) => {
-      this.io.to(`mall-${model.mallId}`).emit('ai-model', {
-        type: 'model-trained',
-        data: model
-      });
-    });
-
-  }
-
-  /**
-   * Setup error handling
-   */
-  private setupErrorHandling(): void {
-    // Global error handler for security and RBAC violations
-    this.app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
-      if (err.name === 'UnauthorizedError') {
-        return res.status(401).json({ success: false, error: 'Unauthorized' });
-      }
-      if (err.status === 403) {
-        return res.status(403).json({ success: false, error: err.message || 'Forbidden' });
-      }
-      logger.error('❌ Global Error:', err);
-      res.status(500).json({ success: false, error: err.message || 'Internal server error' });
-    });
-  }
-
-  /**
-   * Setup graceful shutdown
-   */
-  private setupGracefulShutdown(): void {
-    const gracefulShutdown = async (signal: string) => {
-      logger.info(`🛑 Received ${signal}. Starting graceful shutdown...`);
-
-      try {
-        // Close Socket.IO
-        this.io.close(() => {
-          logger.info('✅ Socket.IO server closed');
-        });
-
-        // Close HTTP server
-        this.server.close(() => {
-          logger.info('✅ HTTP server closed');
-        });
-
-        // Cleanup services
-        await iotService.cleanup();
-        await aiAnalyticsService.cleanup();
-
-        // Close database connections
-        await databaseManager.close();
-        await redis.disconnect();
-
-        logger.info('✅ Graceful shutdown completed');
-        process.exit(0);
-      } catch (error) {
-        logger.error('❌ Error during graceful shutdown:', error);
-        process.exit(1);
-      }
-    };
-
-    process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
-    process.on('SIGINT', () => gracefulShutdown('SIGINT'));
-  }
-
-  /**
-   * Start the application
-   */
-  async start(): Promise<void> {
-    try {
-      await this.initialize();
-
-      const port = config.app.port;
-      this.server.listen(port, '0.0.0.0', () => {
-        logger.info(`🚀 MallOS Enterprise Server running on port ${port}`);
-        logger.info(`📊 Environment: ${config.app.environment}`);
-        logger.info(`🔗 API Documentation: http://localhost:${port}/api`);
-        logger.info(`🏥 Health Check: http://localhost:${port}/healthz`);
-      });
-    } catch (error) {
-      logger.error('❌ Failed to start application:', error);
-      process.exit(1);
+    if (err.status === 403) {
+      return res.status(403).json({ success: false, error: err.message || 'Forbidden' });
     }
-  }
+    logger.error('❌ Global Error:', err);
+    res.status(500).json({ success: false, error: err.message || 'Internal server error' });
+  });
+}
 
-  /**
-   * Get application status
-   */
-  getStatus(): any {
-    return {
-      initialized: this.isInitialized,
-      database: databaseManager.getStatus(),
-      redis: redis.status,
-      iot: iotService.getStatistics(),
-      ai: aiAnalyticsService.getStatistics(),
-      uptime: process.uptime(),
-      memory: process.memoryUsage(),
-      version: config.app.version
-    };
+async function start(): Promise<void> {
+  try {
+    logger.info('🚀 Initializing MallOS Enterprise Application...');
+
+    await databaseManager.initialize();
+    logger.info('✅ Database initialized');
+
+    await redis.connect();
+    logger.info('✅ Redis connected');
+
+    await iotService.initialize();
+    logger.info('✅ IoT Service initialized');
+
+    await aiAnalyticsService.initialize();
+    logger.info('✅ AI Analytics Service initialized');
+
+    setupMiddleware(app);
+    registerRoutes(app);
+    await loadPlugins(app, io);
+    configureWebSocket(io);
+    setupErrorHandling(app);
+    setupGracefulShutdown(server, io);
+
+    const port = config.app.port;
+    server.listen(port, '0.0.0.0', () => {
+      logger.info(`🚀 MallOS Enterprise Server running on port ${port}`);
+      logger.info(`📊 Environment: ${config.app.environment}`);
+      logger.info(`🔗 API Documentation: http://localhost:${port}/api`);
+      logger.info(`🏥 Health Check: http://localhost:${port}/healthz`);
+    });
+  } catch (error) {
+    logger.error('❌ Failed to start application:', error);
+    process.exit(1);
   }
 }
 
-// Create and start the application
-const app = new MallOSApplication();
-
-// Handle uncaught exceptions
 process.on('uncaughtException', (error) => {
   logger.error('❌ Uncaught Exception:', error);
   process.exit(1);
@@ -510,10 +86,10 @@ process.on('unhandledRejection', (reason, promise) => {
   process.exit(1);
 });
 
-// Start the application
-app.start().catch((error) => {
+start().catch((error) => {
   logger.error('❌ Failed to start MallOS Enterprise:', error);
   process.exit(1);
 });
 
 export default app;
+

--- a/src/registerRoutes.ts
+++ b/src/registerRoutes.ts
@@ -1,0 +1,65 @@
+import express from 'express';
+import { authMiddleware } from '@/middleware/auth';
+import aiRoutes from '@/routes/ai';
+import auditLogRouter from '@/routes/audit-logs';
+import authRoutes from '@/routes/auth';
+import cleaningRoutes from '@/routes/cleaning';
+import dashboardRoutes from '@/routes/dashboard';
+import integrationsRouter from '@/routes/integrations';
+import iotRoutes from '@/routes/iot';
+import mallsRoutes from '@/routes/malls';
+import tasksRoutes from '@/routes/tasks';
+import tenantsRoutes from '@/routes/tenants';
+import usersRoutes from '@/routes/users';
+import workPermitsRoutes from '@/routes/work-permits';
+import { config } from '@/config/config';
+
+export function registerRoutes(app: express.Application): void {
+  // API routes
+  app.use('/api/auth', authRoutes);
+  app.use('/api/dashboard', authMiddleware, dashboardRoutes);
+  app.use('/api/users', authMiddleware, usersRoutes);
+  app.use('/api/malls', authMiddleware, mallsRoutes);
+  app.use('/api/tenants', authMiddleware, tenantsRoutes);
+  app.use('/api/work-permits', authMiddleware, workPermitsRoutes);
+  app.use('/api/tasks', tasksRoutes);
+
+  // IoT & AI routes
+  app.use('/api/iot', iotRoutes);
+  app.use('/api/ai', aiRoutes);
+
+  app.use('/api/integrations', integrationsRouter);
+  app.use('/api/audit-logs', auditLogRouter);
+  app.use('/api/cleaning', cleaningRoutes);
+
+  // API documentation
+  app.get('/api', (req, res) => {
+    res.json({
+      name: 'MallOS Enterprise API',
+      version: config.app.version,
+      description: 'IoT & AI Integration Hub for Mall Management',
+      endpoints: {
+        auth: '/api/auth',
+        dashboard: '/api/dashboard',
+        users: '/api/users',
+        malls: '/api/malls',
+        tenants: '/api/tenants',
+        workPermits: '/api/work-permits',
+        tasks: '/api/tasks',
+        iot: '/api/iot',
+        ai: '/api/ai',
+        integrations: '/api/integrations',
+        auditLogs: '/api/audit-logs',
+        cleaning: '/api/cleaning',
+      },
+    });
+  });
+
+  app.use('*', (req, res) => {
+    res.status(404).json({
+      error: 'Endpoint not found',
+      path: req.originalUrl,
+    });
+  });
+}
+

--- a/src/setupMiddleware.ts
+++ b/src/setupMiddleware.ts
@@ -1,0 +1,165 @@
+import { config } from '@/config/config';
+import { databaseManager } from '@/config/database';
+import { redis } from '@/config/redis';
+import { AuditLog } from '@/models/AuditLog';
+import { IntegrationConfig } from '@/models/IntegrationConfig';
+import compression from 'compression';
+import cors from 'cors';
+import cookieParser from 'cookie-parser';
+import express from 'express';
+import helmet from 'helmet';
+import morgan from 'morgan';
+import os from 'os';
+import promClient from 'prom-client';
+import { getRepository } from 'typeorm';
+import { auditLog } from '@/middleware/audit';
+import { rateLimiter } from '@/middleware/rateLimiter';
+import { correlationIdMiddleware } from '@/middleware/correlationId';
+import { logger } from '@/utils/logger';
+
+export function setupMiddleware(app: express.Application): void {
+  // Security middleware
+  app.use(
+    helmet({
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"],
+          scriptSrc: ["'self'"],
+          imgSrc: ["'self'", "data:", "https:"],
+        },
+      },
+    })
+  );
+
+  // CORS
+  app.use(
+    cors({
+      origin: config.app.corsOrigin,
+      credentials: true,
+    })
+  );
+
+  // Rate limiting (global, can be overridden per route)
+  app.use(rateLimiter);
+
+  // Compression
+  app.use(compression());
+
+  // Correlation IDs for request tracing
+  app.use(correlationIdMiddleware);
+
+  // Logging
+  app.use(
+    morgan('combined', {
+      stream: {
+        write: (message: string) => logger.info(message.trim()),
+      },
+    })
+  );
+
+  // Body parsing
+  app.use(express.json({ limit: '10mb' }));
+  app.use(express.urlencoded({ extended: true, limit: '10mb' }));
+
+  // Cookie parsing
+  app.use(cookieParser());
+
+  // Audit logging (global)
+  app.use(auditLog);
+
+  // Health and metrics endpoints
+  app.get('/healthz', (_req, res) => {
+    res.status(200).json({ status: 'ok' });
+  });
+
+  app.get('/health', async (req, res) => {
+    res.json({
+      status: 'healthy',
+      timestamp: new Date().toISOString(),
+      version: config.app.version,
+      environment: config.app.environment,
+      nodeEnv: process.env.NODE_ENV,
+      uptime: process.uptime(),
+      memory: process.memoryUsage(),
+      memoryPercent: (process.memoryUsage().heapUsed / process.memoryUsage().heapTotal) * 100,
+      cpu: os.loadavg(),
+      dependencies: {
+        database: databaseManager.getStatus(),
+        redis: redis.status,
+        integrations: 'ok',
+        security: 'ok',
+      },
+    });
+  });
+
+  app.get('/health/database', async (req, res) => {
+    try {
+      const status = databaseManager.getStatus();
+      const pool = databaseManager.getPoolStatus ? databaseManager.getPoolStatus() : {};
+      const repo = getRepository(AuditLog);
+      const count = await repo.count();
+      res.json({
+        status,
+        pool,
+        auditLogCount: count,
+        migration: databaseManager.getMigrationStatus ? await databaseManager.getMigrationStatus() : 'unknown',
+      });
+    } catch (err: any) {
+      res.status(500).json({ status: 'error', error: err.message });
+    }
+  });
+
+  app.get('/health/integrations', async (req, res) => {
+    try {
+      const repo = getRepository(IntegrationConfig);
+      const integrations = await repo.find();
+      const statuses = integrations.map((i) => ({
+        id: i.id,
+        name: i.name,
+        type: i.type,
+        status: i.status,
+        lastSync: (i as any)['lastSync'] || null,
+        errorCount: (i as any)['errorCount'] || 0,
+      }));
+      res.json({ integrations: statuses });
+    } catch (err: any) {
+      res.status(500).json({ status: 'error', error: err.message });
+    }
+  });
+
+  app.get('/health/security', (req, res) => {
+    res.json({
+      helmet: true,
+      cors: true,
+      rateLimiting: true,
+      recentSecurityEvents: [],
+      authentication: true,
+      auditLogging: true,
+    });
+  });
+
+  app.get('/health/audit', async (req, res) => {
+    try {
+      const repo = getRepository(AuditLog);
+      const count = await repo.count();
+      const recent = await repo.find({ order: { timestamp: 'DESC' }, take: 10 });
+      res.json({
+        logVolume: count,
+        recentLogs: recent,
+        retentionPolicy: process.env.AUDIT_RETENTION_DAYS || 90,
+        cleanupStatus: 'ok',
+      });
+    } catch (err: any) {
+      res.status(500).json({ status: 'error', error: err.message });
+    }
+  });
+
+  const collectDefaultMetrics = promClient.collectDefaultMetrics;
+  collectDefaultMetrics();
+  app.get('/metrics', async (req, res) => {
+    res.set('Content-Type', promClient.register.contentType);
+    res.end(await promClient.register.metrics());
+  });
+}
+

--- a/tests/configureWebSocket.test.js
+++ b/tests/configureWebSocket.test.js
@@ -1,0 +1,24 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+const { configureWebSocket } = require('../src/configureWebSocket');
+
+test('configureWebSocket registers handlers', () => {
+  let used = false;
+  let connectionRegistered = false;
+  const io = {
+    use: () => {
+      used = true;
+    },
+    on: (event, handler) => {
+      if (event === 'connection') {
+        connectionRegistered = typeof handler === 'function';
+      }
+    },
+    to: () => ({ emit: () => {} })
+  };
+
+  configureWebSocket(io);
+  assert.equal(used, true);
+  assert.equal(connectionRegistered, true);
+});

--- a/tests/gracefulShutdown.test.js
+++ b/tests/gracefulShutdown.test.js
@@ -1,0 +1,43 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+const { setupGracefulShutdown } = require('../src/gracefulShutdown');
+const { iotService } = require('../src/services/IoTService');
+const { aiAnalyticsService } = require('../src/services/AIAnalyticsService');
+const { databaseManager } = require('../src/config/database');
+const { redis } = require('../src/config/redis');
+
+test('setupGracefulShutdown registers handlers and closes resources', async () => {
+  let serverClosed = false;
+  let ioClosed = false;
+  const server = { close: (cb) => { serverClosed = true; cb && cb(); } };
+  const io = { close: (cb) => { ioClosed = true; cb && cb(); } };
+
+  let iotClean = false;
+  let aiClean = false;
+  let dbClosed = false;
+  let redisClosed = false;
+  iotService.cleanup = async () => { iotClean = true; };
+  aiAnalyticsService.cleanup = async () => { aiClean = true; };
+  databaseManager.close = async () => { dbClosed = true; };
+  redis.disconnect = async () => { redisClosed = true; };
+
+  let exitCode;
+  const originalExit = process.exit;
+  process.exit = (code) => { exitCode = code; };
+
+  setupGracefulShutdown(server, io);
+  const handler = process.listeners('SIGTERM').pop();
+  handler();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  assert.equal(serverClosed, true);
+  assert.equal(ioClosed, true);
+  assert.equal(iotClean, true);
+  assert.equal(aiClean, true);
+  assert.equal(dbClosed, true);
+  assert.equal(redisClosed, true);
+  assert.equal(exitCode, 0);
+
+  process.exit = originalExit;
+});

--- a/tests/registerRoutes.test.js
+++ b/tests/registerRoutes.test.js
@@ -1,0 +1,15 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+const express = require('express');
+const request = require('supertest');
+const { registerRoutes } = require('../src/registerRoutes');
+
+test('registerRoutes exposes /api info', async () => {
+  const app = express();
+  registerRoutes(app);
+  const res = await request(app).get('/api');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.name, 'MallOS Enterprise API');
+  assert.ok(res.body.endpoints);
+});

--- a/tests/setupMiddleware.test.js
+++ b/tests/setupMiddleware.test.js
@@ -1,0 +1,14 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+require('ts-node/register');
+const express = require('express');
+const request = require('supertest');
+const { setupMiddleware } = require('../src/setupMiddleware');
+
+test('setupMiddleware adds healthz route', async () => {
+  const app = express();
+  setupMiddleware(app);
+  const res = await request(app).get('/healthz');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.status, 'ok');
+});


### PR DESCRIPTION
## Summary
- Modularize server setup by extracting middleware, routes, WebSocket, and shutdown logic
- Streamline `index.ts` to orchestrate high-level initialization using new modules
- Add unit tests verifying middleware, route registration, WebSocket configuration, and graceful shutdown

## Testing
- `npm test` *(fails: Invalid package.json)*
- `node --test tests/*.test.js` *(fails: Error parsing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998e22123c832ea27e0bd5be33ae2f