### PR TITLE
require explicit broker credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,13 @@ cd ..
 ```bash
 cp env.example .env
 # تعديل ملف .env بالمعلومات المطلوبة
+# تأكد من ضبط المتغيرات التالية:
+# MQTT_BROKER_URL
+# MQTT_USERNAME
+# MQTT_PASSWORD
+# RABBITMQ_URL
+# RABBITMQ_USERNAME
+# RABBITMQ_PASSWORD
 ```
 
 4. **إعداد قاعدة البيانات**

--- a/env.example
+++ b/env.example
@@ -3,3 +3,13 @@ PORT=10000
 CORS_ORIGIN=https://your-frontend.onrender.com
 # DATABASE_URL از Render تزریق می‌شود
 # REDIS_URL از Render تزریق می‌شود
+
+# MQTT settings (required)
+MQTT_BROKER_URL=
+MQTT_USERNAME=
+MQTT_PASSWORD=
+
+# RabbitMQ settings (required)
+RABBITMQ_URL=
+RABBITMQ_USERNAME=
+RABBITMQ_PASSWORD=

--- a/src/config/config.ts
+++ b/src/config/config.ts
@@ -86,9 +86,9 @@ export const env = cleanEnv(process.env, {
   AZURE_IOT_HUB_CONNECTION_STRING: str({ default: '' }),
   AZURE_IOT_HUB_HOSTNAME: str({ default: '' }),
 
-  MQTT_BROKER_URL: str({ default: 'mqtt://localhost:1883' }),
-  MQTT_USERNAME: str({ default: 'mallos_iot' }),
-  MQTT_PASSWORD: str({ default: 'mallos_iot_password' }),
+  MQTT_BROKER_URL: str(),
+  MQTT_USERNAME: str(),
+  MQTT_PASSWORD: str(),
 
   SENTRY_DSN: str({ default: '' }),
   SENTRY_ENVIRONMENT: str({ default: 'development' }),
@@ -109,9 +109,9 @@ export const env = cleanEnv(process.env, {
   DOCUSIGN_USER_ID: str({ default: '' }),
   DOCUSIGN_PRIVATE_KEY_PATH: str({ default: './certs/docusign-private-key.pem' }),
 
-  RABBITMQ_URL: str({ default: 'amqp://localhost:5672' }),
-  RABBITMQ_USERNAME: str({ default: 'guest' }),
-  RABBITMQ_PASSWORD: str({ default: 'guest' }),
+  RABBITMQ_URL: str(),
+  RABBITMQ_USERNAME: str(),
+  RABBITMQ_PASSWORD: str(),
 
   KAFKA_BROKERS: str({ default: 'localhost:9092' }),
   KAFKA_CLIENT_ID: str({ default: 'mallos-enterprise' }),
@@ -486,9 +486,9 @@ export const config: Config = {
       iotHubHostname: process.env.AZURE_IOT_HUB_HOSTNAME || '',
     },
     mqtt: {
-      brokerUrl: process.env.MQTT_BROKER_URL || 'mqtt://localhost:1883',
-      username: process.env.MQTT_USERNAME || 'mallos_iot',
-      password: process.env.MQTT_PASSWORD || 'mallos_iot_password',
+      brokerUrl: env.MQTT_BROKER_URL,
+      username: env.MQTT_USERNAME,
+      password: env.MQTT_PASSWORD,
     },
   },
 
@@ -527,9 +527,9 @@ export const config: Config = {
 
   messageQueue: {
     rabbitmq: {
-      url: process.env.RABBITMQ_URL || 'amqp://localhost:5672',
-      username: process.env.RABBITMQ_USERNAME || 'guest',
-      password: process.env.RABBITMQ_PASSWORD || 'guest',
+      url: env.RABBITMQ_URL,
+      username: env.RABBITMQ_USERNAME,
+      password: env.RABBITMQ_PASSWORD,
     },
     kafka: {
       brokers: process.env.KAFKA_BROKERS || 'localhost:9092',


### PR DESCRIPTION
## Summary
- remove hardcoded MQTT and RabbitMQ defaults in config
- document required broker environment variables in README and env.example
- load broker configuration exclusively from environment

## Testing
- `npm test` *(fails: Invalid package.json: Expected double-quoted property name in JSON at position 317)*
- `node -r ts-node/register src/config/config.ts` *(fails: Error parsing /workspace/ops/package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68998e240af4832ea85556de0118543a