### PR TITLE
fix: restore valid package.json for successful npm install

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,23 +1,14 @@
 {
   "name": "ops",
   "private": true,
- codex/fix-render-service-health-check-and-lockfile
-  "engines": {
-    "node": ">=18 <21",
-    "npm": ">=8.0.0"
-  },
-=======
- main
+  "engines": { "node": ">=18 <21" },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js || node dist/index.js",
     "dev": "ts-node src/server.ts || ts-node src/index.ts",
     "migrate:prod": "typeorm migration:run"
   },
- codex/update-build-script-in-package.json
 
-
- main
   "keywords": [
     "mall-management",
     "enterprise",
@@ -144,6 +135,10 @@
     "lint-staged": "^13.2.3",
     "knex": "^2.4.2",
     "sqlite3": "^5.1.6"
+  },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- restore last valid `package.json` so npm can parse the file again

## Testing
- `npm install --package-lock-only` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@sentry%2fnode)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6899911ea808832e89d81dc31d54353a