### PR TITLE
fix(metrics): align prom-client with middleware peer range

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "ops",
   "private": true,
-  "engines": { "node": ">=18 <21" },
+  "engines": {
+    "node": ">=18.0.0",
+    "npm": ">=8.0.0"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "start": "node dist/server.js || node dist/index.js",
     "dev": "ts-node src/server.ts || ts-node src/index.ts",
     "migrate:prod": "typeorm migration:run"
   },
-
   "keywords": [
     "mall-management",
     "enterprise",
@@ -77,7 +79,7 @@
     "node-schedule": "^2.1.1",
     "bull": "^4.11.3",
     "express-prometheus-middleware": "^1.2.0",
-    "prom-client": "^14.2.0",
+    "prom-client": "^13.0.0",
     "@sentry/node": "^7.64.0",
     "newrelic": "^11.0.0",
     "mqtt": "^5.0.3",
@@ -135,10 +137,6 @@
     "lint-staged": "^13.2.3",
     "knex": "^2.4.2",
     "sqlite3": "^5.1.6"
-  },
-  "engines": {
-    "node": ">=18.0.0",
-    "npm": ">=8.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- downgrade prom-client to ^13 to satisfy express-prometheus-middleware peer dependency

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689993e9e878832e8e0802c9e06a1aff