### PR TITLE
fix: remove merge artifacts from auth login route

### DIFF
--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -87,32 +87,16 @@ router.post(
       const accessToken = AuthService.generateAccessToken(user);
       const refreshToken = AuthService.generateRefreshToken(user);
       const sessionId = await AuthService.createSession(user.id, { role: user.role, tenantId: user.tenantId });
-      res.cookie('sessionId', sessionId, { httpOnly: true, secure: true });
+      res.cookie('sessionId', sessionId, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'lax'
+      });
       return res.json({ accessToken, refreshToken, sessionId });
     } catch (err) {
       logger.error('Login error', err);
       return res.status(500).json({ message: 'Login failed' });
     }
- codex/add-validation-middleware-for-auth-routes
-
-    if (user.status !== UserStatus.ACTIVE) {
-      return res.status(403).json({ message: 'Account not active' });
-    }
-    // MFA step (optional)
-    // ...
-    const accessToken = AuthService.generateAccessToken(user);
-    const refreshToken = AuthService.generateRefreshToken(user);
-    const sessionId = await AuthService.createSession(user.id, { role: user.role, tenantId: user.tenantId });
-    res.cookie('sessionId', sessionId, {
-      httpOnly: true,
-      secure: true,
-      sameSite: 'lax'
-    });
-    return res.json({ accessToken, refreshToken, sessionId });
-  } catch (err) {
-    logger.error('Login error', err);
-    return res.status(500).json({ message: 'Login failed' });
- main
   }
 );
 


### PR DESCRIPTION
## Summary
- clean up leftover merge text in auth login route
- ensure login handler closes properly and sets cookie with security options

## Testing
- `npm run build` *(fails: Could not find a declaration file for module 'cookie-parser', Property 'corsOrigin' does not exist, etc.)*
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68999fc7407c832eaa4e4d5b06427b6a